### PR TITLE
Support pytorch acceleration on M1 mac hardware

### DIFF
--- a/projects/mitonet/scripts/evaluate3d.py
+++ b/projects/mitonet/scripts/evaluate3d.py
@@ -71,7 +71,14 @@ if __name__ == "__main__":
             del state_dict[k]
 
     msg = model.load_state_dict(state['state_dict'], strict=True)
-    model.to('cuda' if torch.cuda.is_available() else 'cpu') # move model to GPU 0
+    # check whether GPU or M1 Mac hardware is available
+    if torch.cuda.is_available():
+        device = torch.device('cuda:0')
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
+    model.to(device)
 
     # set the evaluation transforms
     norms = state['norms']

--- a/projects/mitonet/scripts/evaluate3d_bc.py
+++ b/projects/mitonet/scripts/evaluate3d_bc.py
@@ -78,7 +78,14 @@ if __name__ == "__main__":
             del state_dict[k]
 
     msg = model.load_state_dict(state['state_dict'], strict=True)
-    model.to('cuda' if torch.cuda.device_count() > 0 else 'cpu') # move model to GPU 0
+    # check whether GPU or M1 Mac hardware is available
+    if torch.cuda.is_available():
+        device = torch.device('cuda:0')
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
+    model.to(device)
 
     # set the evaluation transforms
     norms = state['norms']

--- a/projects/mitonet/scripts/legacy_data/filter_nn.py
+++ b/projects/mitonet/scripts/legacy_data/filter_nn.py
@@ -58,7 +58,14 @@ if __name__ == "__main__":
     # load the weights from online
     state_dict = torch.hub.load_state_dict_from_url(DEFAULT_WEIGHTS, map_location='cpu')
     msg = model.load_state_dict(state_dict)
-    model = model.to('cuda:0' if torch.cuda.is_available() else 'cpu')
+    # check whether GPU or M1 Mac hardware is available
+    if torch.cuda.is_available():
+        device = torch.device('cuda:0')
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
+    model = model.to(device)
     model = model.eval()
     cudnn.benchmark = True
 
@@ -97,8 +104,15 @@ if __name__ == "__main__":
     tst_predictions = []
     for data in tqdm(test, total=len(test)):
         with torch.no_grad():
-            # load data onto gpu then forward pass
-            images = data['image'].to('cuda:0' if torch.cuda.is_available() else 'cpu', non_blocking=True)
+            # check whether GPU or M1 Mac hardware is available
+            if torch.cuda.is_available():
+                device = torch.device('cuda:0')
+            elif torch.backends.mps.is_available():
+                device = torch.device('mps')
+            else:
+                device = torch.device('cpu')
+            # load data onto backend then do the forward pass
+            images = data['image'].to(device)
             output = model(images)
             predictions = nn.Sigmoid()(output)
 

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -85,9 +85,20 @@ def main():
     main_worker(config)
 
 def main_worker(config):
-    config['device'] = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    # check whether GPU or M1 Mac hardware is available
+    if torch.cuda.is_available():
+        device = torch.device('cuda:0')  
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
+    config['device'] = device
 
-    if str(config['device']) == 'cpu':
+    if str(config['device']) == 'cuda:0':
+        print("Using GPU for training.")
+    elif str(config['device']) == 'mps':
+        print("Using M1 Mac hardware for training.")
+    elif str(config['device']) == 'cpu':
         print(f"Using CPU for training.")
 
     # setup the model and pick dataset class

--- a/scripts/pdl_inference3d.py
+++ b/scripts/pdl_inference3d.py
@@ -61,8 +61,14 @@ if __name__ == "__main__":
     # read the model config file
     config = load_config(args.config)
 
-    # set device and determine model to load
-    device = torch.device("cuda:0" if torch.cuda.is_available() and not args.use_cpu else "cpu")
+    # check whether GPU or M1 Mac hardware is available
+    if torch.cuda.is_available():
+        device = torch.device('cuda:0')
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
+    # determine model to load
     use_quantized = str(device) == 'cpu' and config.get('model_quantized') is not None
     model_key = 'model_quantized' if use_quantized  else 'model'
     


### PR DESCRIPTION
DO NOT MERGE
1. We're waiting for the next official release of pytorch including M1 Mac hardware accleration (right now I'm using the nightly build to test things)
2. The MitoNet model is not supported on the M1 Mac mps backend, so things are broken now because of that as well

The pytorch nightly (I'm using version '1.13.0.dev20220616') [now supports acceleration on M1 Mac hardware](https://pytorch.org/blog/introducing-accelerated-pytorch-training-on-mac/). This branch experiments with adding support for this in empanada-napari.

Cross-reference: https://github.com/volume-em/empanada-napari/pull/17